### PR TITLE
["latex", "verbatim"] make portable by using cat

### DIFF
--- a/latex/RULES
+++ b/latex/RULES
@@ -101,16 +101,26 @@
                 [ [ "action out"
                   , { "type": "ACTION"
                     , "inputs":
-                      { "type": "singleton_map"
-                      , "key": "in"
-                      , "value": {"type": "var", "name": "input"}
+                      { "type": "map_union"
+                      , "$1":
+                        [ { "type": "singleton_map"
+                          , "key": "in"
+                          , "value": {"type": "var", "name": "input"}
+                          }
+                        , { "type": "singleton_map"
+                          , "key": "begin"
+                          , "value":
+                            {"type": "BLOB", "data": "\\begin{verbatim}\n"}
+                          }
+                        , { "type": "singleton_map"
+                          , "key": "end"
+                          , "value":
+                            {"type": "BLOB", "data": "\\end{verbatim}\n"}
+                          }
+                        ]
                       }
                     , "outs": ["out"]
-                    , "cmd":
-                      [ "sh"
-                      , "-c"
-                      , "echo '\\\\begin{verbatim}' > out && cat in >> out && echo '\\\\end{verbatim}' >> out"
-                      ]
+                    , "cmd": ["sh", "-c", "cat begin in end > out"]
                     }
                   ]
                 , [ "out"


### PR DESCRIPTION
... and the BLOB construct instead of echo.

The echo(1) function is usually shell built in. This in itself is a reasonalbe design decission, as there is no need to start an external program just to join a couple of strings by spaces. Unfortunately, however, shells don't agree on the semantics of echo, in particular about what the correct invocation is to output a literal backslash; this can be seen from the following invovations.

  ~>dash -c 'echo '\''\\'\'''
  \
  ~>bash -c 'echo '\''\\'\'''
  \\
  ~>

Now, both of those shells can act as the, supposedly POSIX-compliant sh. Work around these incompatibilities by generating BLOBs for the \begin/\end{verbatim} literal and join them with cat(1).