### PR TITLE
Support execution properties for typesetting actions

### DIFF
--- a/latex/EXPRESSIONS
+++ b/latex/EXPRESSIONS
@@ -10,6 +10,7 @@
     , "runner type"
     , "opts"
     , "output file extension"
+    , "TYPESETTING_EXECUTION_PROPERTIES"
     ]
   , "expression":
     { "type": "let*"
@@ -182,6 +183,11 @@
             ]
           , "cmd": {"type": "var", "name": "cmd"}
           , "env": {"type": "var", "name": "env"}
+          , "execution properties":
+            { "type": "var"
+            , "name": "TYPESETTING_EXECUTION_PROPERTIES"
+            , "default": {"type": "empty_map"}
+            }
           }
         ]
       , [ "output file"

--- a/latex/RULES
+++ b/latex/RULES
@@ -20,12 +20,16 @@
       , "of a .tex file in \"srcs\"; the \"stage\" is prepended automatically."
       ]
     }
-  , "config_vars": ["env", "latex"]
+  , "config_vars": ["env", "latex", "TYPESETTING_EXECUTION_PROPERTIES"]
   , "config_doc":
     { "latex": ["Name of the latex command, defaults to \"pdflatex\"."]
     , "env":
       [ "Any override to the default environment which sets only"
       , "PATH and SOURCE_DATE_EPOCH"
+      ]
+    , "TYPESETTING_EXECUTION_PROPERTIES":
+      [ "Map of additional remote-execution properties to add for the typesetting"
+      , "actions; defaults to the empty map."
       ]
     }
   , "implicit": {"runner": ["latex_runner.sh"]}
@@ -200,13 +204,17 @@
       , "If omitted, \".pdf\" is assumed."
       ]
     }
-  , "config_vars": ["env", "latexmk"]
+  , "config_vars": ["env", "latexmk", "TYPESETTING_EXECUTION_PROPERTIES"]
   , "config_doc":
     { "env":
       [ "Any override to the default environment which sets only"
       , "PATH and SOURCE_DATE_EPOCH"
       ]
     , "latexmk": ["Name of the latexmk command, defaults to \"latexmk\"."]
+    , "TYPESETTING_EXECUTION_PROPERTIES":
+      [ "Map of additional remote-execution properties to add for the typesetting"
+      , "actions; defaults to the empty map."
+      ]
     }
   , "imports": {"call latex": "call latex"}
   , "expression":

--- a/pandoc/RULES
+++ b/pandoc/RULES
@@ -168,11 +168,15 @@
     , "meta data files":
       ["Additional meta data files to be taken into account"]
     }
-  , "config_vars": ["env"]
+  , "config_vars": ["env", "TYPESETTING_EXECUTION_PROPERTIES"]
   , "config_doc":
     { "env":
       [ "Any override to the default environment which sets only"
       , "PATH, SOURCE_DATE_EPOCH, and TEXINPUTS"
+      ]
+    , "TYPESETTING_EXECUTION_PROPERTIES":
+      [ "Map of additional remote-execution properties to add for the typesetting"
+      , "actions; defaults to the empty map."
       ]
     }
   , "implicit": {"metadata": [["./", ".", "metadata"]]}
@@ -471,6 +475,11 @@
               , {"type": "var", "name": "meta data args"}
               , {"type": "var", "name": "src names"}
               ]
+            }
+          , "execution properties":
+            { "type": "var"
+            , "name": "TYPESETTING_EXECUTION_PROPERTIES"
+            , "default": {"type": "empty_map"}
             }
           }
         ]


### PR DESCRIPTION
... in order to allow a specialized typesetting image to be used, so that the (potentially large) typesetting dependencies do not have to be installed in the normal build images.