### PR TITLE
Honor "env" for all actions

### DIFF
--- a/latex/RULES
+++ b/latex/RULES
@@ -72,6 +72,9 @@
     , "prefix": ["Additional prefix to add to the output file name"]
     , "stage": ["The logical directory to stage the outputs to"]
     }
+  , "config_vars": ["env"]
+  , "config_doc":
+    {"env": ["Any override to the default environment which sets only PATH."]}
   , "expression":
     { "type": "let*"
     , "bindings":
@@ -125,6 +128,19 @@
                       }
                     , "outs": ["out"]
                     , "cmd": ["sh", "-c", "cat begin in end > out"]
+                    , "env":
+                      { "type": "map_union"
+                      , "$1":
+                        [ { "type": "singleton_map"
+                          , "key": "PATH"
+                          , "value": "/bin:/usr/bin:/usr/local/bin"
+                          }
+                        , { "type": "var"
+                          , "name": "env"
+                          , "default": {"type": "empty_map"}
+                          }
+                        ]
+                      }
                     }
                   ]
                 , [ "out"

--- a/pandoc/RULES
+++ b/pandoc/RULES
@@ -78,7 +78,7 @@
 , "metadata":
   { "doc":
     ["Generate a file with meta data from data provided through context"]
-  , "config_vars": ["SOURCE_DATE_EPOCH", "DATE_FORMAT"]
+  , "config_vars": ["SOURCE_DATE_EPOCH", "DATE_FORMAT", "env"]
   , "config_doc":
     { "SOURCE_DATE_EPOCH":
       [ "The timestamp to include (in seconds since Jan 1, 1970 00:00 UTC);"
@@ -86,6 +86,7 @@
       ]
     , "DATE_FORMAT":
       ["The format to use for time stamps (defaults to \"%Y-%m-%d %H:%M\")."]
+    , "env": ["Any override to the default environment which sets only PATH."]
     }
   , "expression":
     { "type": "let*"
@@ -141,6 +142,19 @@
             , "key": "generate"
             , "value":
               {"type": "BLOB", "data": {"type": "var", "name": "script"}}
+            }
+          , "env":
+            { "type": "map_union"
+            , "$1":
+              [ { "type": "singleton_map"
+                , "key": "PATH"
+                , "value": "/bin:/usr/bin:/usr/local/bin"
+                }
+              , { "type": "var"
+                , "name": "env"
+                , "default": {"type": "empty_map"}
+                }
+              ]
             }
           }
         ]
@@ -437,7 +451,7 @@
           , "else": {"type": "var", "name": "src names"}
           , "then":
             { "type": "foreach"
-            , "range": {"type": "var", "name":"src names"}
+            , "range": {"type": "var", "name": "src names"}
             , "body":
               { "type": "change_ending"
               , "ending": {"type": "var", "name": ".via"}

--- a/ps/RULES
+++ b/ps/RULES
@@ -15,6 +15,9 @@
       , "The stage name will be appended, separated by \"_\", and the ending \".eps\" will be added"
       ]
     }
+  , "config_vars": ["env"]
+  , "config_doc":
+    {"env": ["Any override to the default environment which sets only PATH."]}
   , "imports": {"stage_field": ["./", "..", "stage_singleton_field"]}
   , "expression":
     { "type": "let*"
@@ -81,6 +84,19 @@
                       , "-c"
                       , "cp src.eps out.eps && chmod 644 out.eps && { ed out.eps < script.ed > log 2>&1 || { cat log ; exit 1; } }"
                       ]
+                    , "env":
+                      { "type": "map_union"
+                      , "$1":
+                        [ { "type": "singleton_map"
+                          , "key": "PATH"
+                          , "value": "/bin:/usr/bin:/usr/local/bin"
+                          }
+                        , { "type": "var"
+                          , "name": "env"
+                          , "default": {"type": "empty_map"}
+                          }
+                        ]
+                      }
                     }
                   ]
                 ]


### PR DESCRIPTION
... including basic ones that only call tools like cat(1). In all cases, use the same default for PATH as for ["latex", "standalone"].